### PR TITLE
Correct String-with-32-bit-size marker byte

### DIFF
--- a/modules/ROOT/pages/packstream/index.adoc
+++ b/modules/ROOT/pages/packstream/index.adoc
@@ -455,7 +455,7 @@ For longer strings:
 | 16-bit big-endian unsigned integer
 | 65 535 bytes
 
-| `D3`
+| `D2`
 | 32-bit big-endian unsigned integer
 | 2 147 483 647 bytes
 |===


### PR DESCRIPTION
See [Neo4J's Javascript Driver](https://github.com/neo4j/neo4j-javascript-driver/blob/b1fd33c9ac95dd3dfbf23879b5e662dd4eb3811d/packages/bolt-connection/src/packstream/packstream-v1.js#L46C21-L46C21)