### PR TITLE
Update bolt-compatibility.adoc

### DIFF
--- a/modules/ROOT/pages/bolt-compatibility.adoc
+++ b/modules/ROOT/pages/bolt-compatibility.adoc
@@ -98,8 +98,7 @@
 
 |===
 
-Bolt version 5.5 is flawed and should not be used.
-No Neo4j server will negotiate it.
+Bolt version 5.5 is not used and no Neo4j server will ever negotiate it.
 
 == Bolt 4.x
 


### PR DESCRIPTION
Toned down the warning about bolt 5.5 to avoid alarming customers.