### PR TITLE
DOCOPS-161 Harden docs-cla.yml (add explicit contents:read permissions)

### DIFF
--- a/.github/workflows/docs-cla.yml
+++ b/.github/workflows/docs-cla.yml
@@ -1,5 +1,8 @@
 name: "CLA Check"
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     branches:


### PR DESCRIPTION
## What

Adds an explicit `permissions: contents: read` block to `.github/workflows/docs-cla.yml`.

## Why

This workflow runs on `pull_request_target`, which otherwise hands the job a *write*-scoped `GITHUB_TOKEN` even on fork PRs. All privileged work uses `DOCS_CHECKS_TOKEN` (a PAT), so the default token needs nothing — `contents: read` is set as an explicit least-privilege floor. (The `checkout`/`setup-python` actions are already SHA-pinned in this repo.)

Resolves the CodeQL `actions/missing-workflow-permissions` alert on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
